### PR TITLE
Closes #278 - Checked forgot password feature

### DIFF
--- a/src/main/resources/mailTemplates/restorePasswordMailTemplate.html
+++ b/src/main/resources/mailTemplates/restorePasswordMailTemplate.html
@@ -27,8 +27,8 @@
                             </tr>
                             <tr>
                                 <td style="word-break: break-all;" width="100%">
-                                    Link for reset password: <a href="${url}/restorePassword?token=${token}" rel="link">
-                                    ${url}/restorePassword?token=${token}</a><br><br>
+                                    <a href="${url}/restorePassword?token=${token}" rel="link">
+                                        Restore password to ORLP <Account></Account></a><br><br>
                                     Infolve team
                                 </td>
                             </tr>


### PR DESCRIPTION
Feature works as intended, however I changed the structure of the Restore Password letter.
Before the change Restore Password letter contained entire link
After the change it looks like this: Restore password to ORLP Account